### PR TITLE
S3policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Uses [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-ex
 
 Specifically configured to run with MSI's S3.
 
-Have your aws key and secret ready! This are taken as arguments.
+Have your aws key and secret ready! They are taken as arguments.
 
 
 ## s3_get_x500

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ separate-errors-into-csvs.py
 	Specify a list of cuBIDS errors that this script will divide out into separate csvs for each error.
 	The output txt files will be named <error_name>-errors.txt
 	
+
+## s3_get_bucket_policy
+
+Uses [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-example-bucket-policies.html) to get and print out a bucket's policy JSON.
+
+Specifically configured to run with MSI's S3.
+
+Have your aws key and secret ready! This are taken as arguments.
+
+
 ## s3_get_x500
 
 ## session_tsv_maker

--- a/s3_get_bucket_policy/get_bucket_policy.py
+++ b/s3_get_bucket_policy/get_bucket_policy.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import boto3
+import argparse
+
+parser = argparse.ArgumentParser(description="Prints the bucket policy for an S3 bucket on MSI.")
+parser.add_argument("bucket", help=("The name of the s3 bucket to get the policy from." " Do not include the 's3://' prefix."))
+parser.add_argument("aws_key", help=("Your S3 access key." " See https://www.msi.umn.edu/content/second-tier-storage"))
+parser.add_argument("aws_secret", help=("Your S3 secret key." " See https://www.msi.umn.edu/content/second-tier-storage"))
+args = parser.parse_args()
+
+# Retrieve the policy of the specified bucket
+session = boto3.Session()
+s3host = 'https://s3.msi.umn.edu'
+s3client = session.client(service_name='s3',
+                            endpoint_url=s3host,
+                            aws_access_key_id=args.aws_key,
+                            aws_secret_access_key=args.aws_secret)
+
+result = s3client.get_bucket_policy(Bucket=args.bucket)
+print(result['Policy'])


### PR DESCRIPTION
s3cmd does not have this functionality.
Uses boto3 to get and print a bucket policy.
Could be improved by returning x500s, automatically loading the users s3 creds.

Potential to build off of this code to make a new s3 update policy script that does not need a full list of users every time.